### PR TITLE
Add HTTP proxy support when UAA is TLS-enabled

### DIFF
--- a/client.go
+++ b/client.go
@@ -131,6 +131,7 @@ func newSecureClient(cfg *config.Config) (*http.Client, error) {
 
 	tr := &http.Transport{
 		TLSClientConfig: tlsConfig,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 
 	client := &http.Client{Transport: tr}


### PR DESCRIPTION
According to the [`net/http` package documentation](https://golang.org/pkg/net/http), the `DefaultTransport` used by the `DefaultClient` takes HTTP proxy configuration from the `HTTP_PROXY` and `NO_PROXY` environment variables:

> DefaultTransport is the default implementation of Transport and is used by DefaultClient. It establishes network connections as needed and caches them for reuse by subsequent calls. It uses HTTP proxies as directed by the $HTTP_PROXY and $NO_PROXY (or $http_proxy and $no_proxy) environment variables. 

When we pass an `http` endpoint to the UAA Go client constructor ([`NewClient()`](https://github.com/cloudfoundry-incubator/uaa-go-client/blob/master/client.go#L65)), [it uses the `http.DefaultClient`](https://github.com/cloudfoundry-incubator/uaa-go-client/blob/master/client.go#L89) to do the requests, and therefore uses the aforementioned proxy settings.

However, when we give an `https` endpoint to the constructor, an HTTP client is built with [`newSecureClient()`](https://github.com/cloudfoundry-incubator/uaa-go-client/blob/master/client.go#L117). A [custom `http.Transport` is defined](https://github.com/cloudfoundry-incubator/uaa-go-client/blob/master/client.go#L132) which does not set any proxy settings.

This PR makes the custom `http.Transport` used when TLS is enabled use the same HTTP proxy configurations as the `DefaultTransport`. This change allows the client to access a TLS-enabled UAA when going through an HTTP proxy is necessary.